### PR TITLE
chore: bump evm-lens dependency to v0.1.1

### DIFF
--- a/crates/evm-lens/Cargo.toml
+++ b/crates/evm-lens/Cargo.toml
@@ -20,7 +20,7 @@ colored.workspace = true
 clap.workspace = true
 color-eyre.workspace = true
 hex.workspace = true
-evm-lens-core = { version = "0.1.0", path = "../evm-lens-core" }
+evm-lens-core = { version = "0.1.1", path = "../evm-lens-core" }
 # I/O module dependencies
 tokio.workspace = true
 serde.workspace = true


### PR DESCRIPTION
Update evm-lens dependency to v0.1.1 