### PR TITLE
feat: stats flag to get opcode statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ echo "0x60FF61ABCD00" | evm-lens --stdin
 
 # From contract address (fetches from blockchain)
 evm-lens --address 0x123... --rpc https://eth.llamarpc.com
+
+# Show bytecode statistics
+evm-lens 60FF61ABCD00 --stats
 ```
 
 **Library:**
@@ -70,12 +73,10 @@ for (position, opcode) in ops {
 
 ## 🎨 Features
 
-- **🚀 Fast**: Built on revm's optimized EVM implementation
-- **🎨 Beautiful**: Color-coded output for different opcode categories
-- **✅ Accurate**: Proper handling of PUSH instruction immediates
-- **📍 Precise**: Exact position tracking for all opcodes
-- **🔗 Versatile**: Multiple input sources - hex strings, files, stdin, and blockchain
-- **🌐 Connected**: Fetch live contract bytecode from Ethereum networks
+**Core Capabilities:**
+- **🔍 Disassemble EVM bytecode** from multiple sources - hex strings, files, stdin, and live contract addresses
+- **📊 Generate statistics summary** including bytecode length, number of opcodes, and maximum stack depth
+
 
 
 ## 📥 Input Methods
@@ -109,14 +110,6 @@ evm-lens --address 0x123... --rpc https://mainnet.infura.io/v3/YOUR_KEY
 evm-lens --address 0x123... --rpc https://eth.llamarpc.com
 ```
 
-## 🎯 Use Cases
-
-- **Smart Contract Analysis**: Understand deployed contract behavior
-- **Security Research**: Analyze suspicious or malicious contracts  
-- **Bytecode Debugging**: Debug Solidity compilation issues
-- **Education**: Learn EVM opcodes and instruction structure
-- **Development Tools**: Build bytecode analysis into your workflow
-- **Live Contract Inspection**: Analyze contracts directly from the blockchain
 
 ## 📊 Example Output
 
@@ -130,6 +123,22 @@ EVM BYTECODE DISASSEMBLY
 0007 │ RETURN    # Termination (white)
 ==================================================
 5 opcodes total
+```
+
+**With `--stats` flag:**
+```
+EVM BYTECODE DISASSEMBLY
+==================================================
+0000 │ PUSH1
+0002 │ PUSH2
+0005 │ STOP
+==================================================
+3 opcodes total
+BYTECODE STATISTICS
+==================================================
+Byte length: 6
+Number of opcodes: 3
+Max stack depth: 2
 ```
 
 
@@ -161,7 +170,7 @@ cargo test --workspace
 cargo run -p evm-lens -- 60FF61ABCD00
 cargo run -p evm-lens -- --file examples/bytecode.txt
 echo "0x60FF61ABCD00" | cargo run -p evm-lens -- --stdin
-cargo run -p evm-lens -- --address 0x... --rpc https://eth.llamarpc.com
+cargo run -p evm-lens -- --address 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 --rpc https://eth.llamarpc.com
 
 # Test the library
 cargo run --example basic -p evm-lens-core

--- a/crates/evm-lens-core/src/lib.rs
+++ b/crates/evm-lens-core/src/lib.rs
@@ -3,6 +3,9 @@ use revm::{
     primitives::Bytes,
 };
 
+pub mod stats;
+pub use stats::{Stats, StatsError, compute_stats};
+
 #[derive(Debug)]
 pub enum DisassemblyError {
     InvalidBytecode(String),
@@ -82,6 +85,47 @@ pub fn disassemble(bytes: &[u8]) -> Result<Vec<(usize, OpCode)>, DisassemblyErro
     Ok(result)
 }
 
+/// Computes and returns statistics for the given bytecode.
+///
+/// This function takes raw bytecode bytes and returns comprehensive statistics
+/// including byte length, opcode count, maximum stack depth, and other metrics.
+///
+/// # Arguments
+///
+/// * `bytes` - A slice of bytes containing the raw EVM bytecode
+///
+/// # Returns
+///
+/// * `Ok(Stats)` - Statistics about the bytecode
+/// * `Err(DisassemblyError)` - If the bytecode is invalid
+///
+/// # Example
+///
+/// ```
+/// use evm_lens_core::get_stats;
+///
+/// let bytecode = hex::decode("60FF600101").unwrap(); // PUSH1 0xFF, PUSH1 0x01, ADD
+/// let stats = get_stats(&bytecode).unwrap();
+/// println!("Bytecode length: {} bytes", stats.byte_len);
+/// println!("Number of opcodes: {}", stats.opcode_count);
+/// ```
+pub fn get_stats(bytes: &[u8]) -> Result<Stats, DisassemblyError> {
+    if bytes.is_empty() {
+        return Err(DisassemblyError::EmptyBytecode);
+    }
+
+    let bytecode = match Bytecode::new_raw_checked(Bytes::from(bytes.to_vec())) {
+        Ok(bytecode) => bytecode,
+        Err(e) => return Err(DisassemblyError::InvalidBytecode(e.to_string())),
+    };
+
+    compute_stats(&bytecode).map_err(|e| match e {
+        StatsError::UnknownOpcode(opcode) => DisassemblyError::MalformedInstruction {
+            position: 0, // We don't have position info from stats error
+            byte: opcode,
+        },
+    })
+}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -146,6 +190,28 @@ mod tests {
     fn empty_bytecode_error() {
         let bytes = vec![];
         let result = disassemble(&bytes);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            DisassemblyError::EmptyBytecode => {} // Expected
+            _ => panic!("Expected EmptyBytecode error"),
+        }
+    }
+
+    #[test]
+    fn test_get_stats() {
+        // PUSH1 0xFF, PUSH1 0x01, ADD, STOP
+        let bytes = hex::decode("60FF60010100").unwrap(); 
+        let stats = get_stats(&bytes).unwrap();
+        
+        assert_eq!(stats.byte_len, 6);
+        assert_eq!(stats.opcode_count, 4);
+        assert!(stats.max_stack_depth > 0);
+    }
+
+    #[test]
+    fn test_stats_with_empty_bytecode() {
+        let bytes = vec![];
+        let result = get_stats(&bytes);
         assert!(result.is_err());
         match result.unwrap_err() {
             DisassemblyError::EmptyBytecode => {} // Expected

--- a/crates/evm-lens-core/src/lib.rs
+++ b/crates/evm-lens-core/src/lib.rs
@@ -200,9 +200,9 @@ mod tests {
     #[test]
     fn test_get_stats() {
         // PUSH1 0xFF, PUSH1 0x01, ADD, STOP
-        let bytes = hex::decode("60FF60010100").unwrap(); 
+        let bytes = hex::decode("60FF60010100").unwrap();
         let stats = get_stats(&bytes).unwrap();
-        
+
         assert_eq!(stats.byte_len, 6);
         assert_eq!(stats.opcode_count, 4);
         assert!(stats.max_stack_depth > 0);

--- a/crates/evm-lens-core/src/stats.rs
+++ b/crates/evm-lens-core/src/stats.rs
@@ -1,15 +1,15 @@
-use revm::{bytecode::{opcode::{OPCODE_INFO}, Bytecode}};
+use revm::bytecode::{Bytecode, opcode::OPCODE_INFO};
 
 #[derive(Debug)]
 pub struct Stats {
-  pub byte_len: usize,
-  pub opcode_count: usize,
-  pub max_stack_depth: usize
+    pub byte_len: usize,
+    pub opcode_count: usize,
+    pub max_stack_depth: usize,
 }
 
 #[derive(Debug)]
 pub enum StatsError {
-  UnknownOpcode(u8),
+    UnknownOpcode(u8),
 }
 
 impl std::fmt::Display for StatsError {
@@ -25,223 +25,222 @@ impl std::fmt::Display for StatsError {
 impl std::error::Error for StatsError {}
 
 pub fn compute_stats(bytecode: &Bytecode) -> Result<Stats, StatsError> {
-  // Count the number of opcodes
-  let opcode_count = compute_opcode_count(bytecode);
+    // Count the number of opcodes
+    let opcode_count = compute_opcode_count(bytecode);
 
-  // Get total byte length
-  let byte_len = get_byte_len(bytecode);
+    // Get total byte length
+    let byte_len = get_byte_len(bytecode);
 
-  // Track PUSH / POP depth
-  let max_stack_depth = compute_max_stack_depth(bytecode)?;
+    // Track PUSH / POP depth
+    let max_stack_depth = compute_max_stack_depth(bytecode)?;
 
-  Ok(Stats {
-    byte_len,
-    opcode_count,
-    max_stack_depth,
-  })
+    Ok(Stats {
+        byte_len,
+        opcode_count,
+        max_stack_depth,
+    })
 }
 
 fn compute_opcode_count(bytecode: &Bytecode) -> usize {
-  let iter = bytecode.iter_opcodes();
-  iter.count()
+    let iter = bytecode.iter_opcodes();
+    iter.count()
 }
 
 fn get_byte_len(bytecode: &Bytecode) -> usize {
-  bytecode.bytecode().as_ref().len()
+    bytecode.bytecode().as_ref().len()
 }
 
 fn compute_max_stack_depth(bytecode: &Bytecode) -> Result<usize, StatsError> {
-  let mut iter = bytecode.iter_opcodes();
-  let mut max_depth: i32 = 0;
-  let mut depth: i32 = 0;
+    let mut iter = bytecode.iter_opcodes();
+    let mut max_depth: i32 = 0;
+    let mut depth: i32 = 0;
 
-  while let Some(opcode) = iter.peek_opcode() {
-    let opcode_info = OPCODE_INFO[opcode.get() as usize];
+    while let Some(opcode) = iter.peek_opcode() {
+        let opcode_info = OPCODE_INFO[opcode.get() as usize];
 
-    match opcode_info {
-      Some(opcode_info) => {
-        depth += opcode_info.io_diff() as i32;
-      }
-      None => {
-        // If the opcode is not found, it's an invalid opcode
-        return Err(StatsError::UnknownOpcode(opcode.get()));
-      }
+        match opcode_info {
+            Some(opcode_info) => {
+                depth += opcode_info.io_diff() as i32;
+            }
+            None => {
+                // If the opcode is not found, it's an invalid opcode
+                return Err(StatsError::UnknownOpcode(opcode.get()));
+            }
+        }
+
+        max_depth = max_depth.max(depth);
+        iter.next();
     }
 
-    max_depth = max_depth.max(depth);
-    iter.next();
-  }
-
-  Ok(max_depth as usize)
+    Ok(max_depth as usize)
 }
-
 
 #[cfg(test)]
 mod tests {
-  use super::*;
-  use revm::primitives::Bytes;
+    use super::*;
+    use revm::primitives::Bytes;
 
-  #[test]
-  fn test_simple_bytecode_stats() {
-    // PUSH1 0xFF, STOP
-    let bytes = hex::decode("60FF00").unwrap();
-    let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
-    
-    let stats = compute_stats(&bytecode).unwrap();
-    assert_eq!(stats.byte_len, 3);
-    assert_eq!(stats.opcode_count, 2);
-    assert_eq!(stats.max_stack_depth, 1); // PUSH1 adds 1 to stack
-  }
+    #[test]
+    fn test_simple_bytecode_stats() {
+        // PUSH1 0xFF, STOP
+        let bytes = hex::decode("60FF00").unwrap();
+        let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
 
-  #[test]
-  fn test_complex_bytecode_stats() {
-    // PUSH1 0x01, PUSH1 0x02, ADD, STOP
-    let bytes = hex::decode("600160020100").unwrap();
-    let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
-    
-    let stats = compute_stats(&bytecode).unwrap();
-    assert_eq!(stats.byte_len, 6);
-    assert_eq!(stats.opcode_count, 4);
-    assert_eq!(stats.max_stack_depth, 2); // Max depth when both PUSH1s are on stack
-  }
-
-  #[test]
-  fn test_stack_operations() {
-    // PUSH1 0x01, PUSH1 0x02, DUP1, SWAP1, ADD, STOP
-    let bytes = hex::decode("6001600280900100").unwrap();
-    let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
-    
-    let stats = compute_stats(&bytecode).unwrap();
-    assert_eq!(stats.byte_len, 8);
-    assert_eq!(stats.opcode_count, 6);
-    assert_eq!(stats.max_stack_depth, 3); // DUP1 increases stack depth to 3
-  }
-
-  #[test]
-  fn test_memory_operations() {
-    // PUSH1 0x20, PUSH1 0x00, MSTORE, PUSH1 0x00, MLOAD, STOP
-    let bytes = hex::decode("602060005260005100").unwrap();
-    let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
-    
-    let stats = compute_stats(&bytecode).unwrap();
-    assert_eq!(stats.byte_len, 9);
-    assert_eq!(stats.opcode_count, 6);
-    assert_eq!(stats.max_stack_depth, 2); // Max when PUSH1 values are on stack
-  }
-
-  #[test]
-  fn test_push_operations() {
-    // PUSH1 0xFF, PUSH2 0xABCD, PUSH32 (32 bytes of data), STOP
-    let mut bytes = vec![0x60, 0xFF]; // PUSH1 0xFF
-    bytes.extend_from_slice(&[0x61, 0xAB, 0xCD]); // PUSH2 0xABCD
-    bytes.push(0x7F); // PUSH32
-    bytes.extend_from_slice(&[0xFF; 32]); // 32 bytes of 0xFF
-    bytes.push(0x00); // STOP
-    
-    let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
-    
-    let stats = compute_stats(&bytecode).unwrap();
-    assert_eq!(stats.byte_len, 39); // 2 + 3 + 1 + 32 + 1 = 39
-    assert_eq!(stats.opcode_count, 4);
-    assert_eq!(stats.max_stack_depth, 3); // All three PUSH operations on stack
-  }
-
-  #[test]
-  fn test_arithmetic_operations() {
-    // PUSH1 0x05, PUSH1 0x03, ADD, PUSH1 0x02, MUL, STOP
-    let bytes = hex::decode("600560030160020200").unwrap();
-    let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
-    
-    let stats = compute_stats(&bytecode).unwrap();
-    assert_eq!(stats.byte_len, 9);
-    assert_eq!(stats.opcode_count, 6);
-    assert_eq!(stats.max_stack_depth, 2); // Max depth when two values are on stack
-  }
-
-  #[test]
-  fn test_single_opcode() {
-    // Just STOP
-    let bytes = hex::decode("00").unwrap();
-    let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
-    
-    let stats = compute_stats(&bytecode).unwrap();
-    assert_eq!(stats.byte_len, 1);
-    assert_eq!(stats.opcode_count, 1);
-    assert_eq!(stats.max_stack_depth, 0); // STOP doesn't affect stack
-  }
-
-  #[test]
-  fn test_large_bytecode() {
-    // Create a larger bytecode with many operations
-    let mut bytes = Vec::new();
-    
-    // Add 20 PUSH1 operations (reduced from 50 for simpler test)
-    for i in 0..20 {
-      bytes.push(0x60); // PUSH1
-      bytes.push(i as u8); // value
+        let stats = compute_stats(&bytecode).unwrap();
+        assert_eq!(stats.byte_len, 3);
+        assert_eq!(stats.opcode_count, 2);
+        assert_eq!(stats.max_stack_depth, 1); // PUSH1 adds 1 to stack
     }
-    bytes.push(0x00); // STOP
-    
-    let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
-    
-    let stats = compute_stats(&bytecode).unwrap();
-    assert_eq!(stats.byte_len, 41); // 20 * 2 + 1
-    assert_eq!(stats.opcode_count, 21); // 20 PUSH1s + 1 STOP
-    assert_eq!(stats.max_stack_depth, 20); // All PUSH1s accumulate on stack
-  }
 
-  #[test]
-  fn test_compute_opcode_count() {
-    let bytes = hex::decode("60FF61ABCD00").unwrap(); // PUSH1, PUSH2, STOP
-    let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
-    
-    let count = compute_opcode_count(&bytecode);
-    assert_eq!(count, 3);
-  }
+    #[test]
+    fn test_complex_bytecode_stats() {
+        // PUSH1 0x01, PUSH1 0x02, ADD, STOP
+        let bytes = hex::decode("600160020100").unwrap();
+        let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
 
-  #[test]
-  fn test_get_byte_len() {
-    let bytes = hex::decode("60FF61ABCD00").unwrap();
-    let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
-    
-    let len = get_byte_len(&bytecode);
-    assert_eq!(len, 6);
-  }
+        let stats = compute_stats(&bytecode).unwrap();
+        assert_eq!(stats.byte_len, 6);
+        assert_eq!(stats.opcode_count, 4);
+        assert_eq!(stats.max_stack_depth, 2); // Max depth when both PUSH1s are on stack
+    }
 
-  #[test]
-  fn test_compute_max_stack_depth() {
-    let bytes = hex::decode("60FF00").unwrap(); // PUSH1 0xFF, STOP
-    let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
-    
-    let depth = compute_max_stack_depth(&bytecode).unwrap();
-    assert_eq!(depth, 1);
-  }
+    #[test]
+    fn test_stack_operations() {
+        // PUSH1 0x01, PUSH1 0x02, DUP1, SWAP1, ADD, STOP
+        let bytes = hex::decode("6001600280900100").unwrap();
+        let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
 
-  #[test]
-  fn test_zero_stack_depth() {
-    let bytes = hex::decode("00").unwrap(); // Just STOP
-    let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
-    
-    let depth = compute_max_stack_depth(&bytecode).unwrap();
-    assert_eq!(depth, 0);
-  }
+        let stats = compute_stats(&bytecode).unwrap();
+        assert_eq!(stats.byte_len, 8);
+        assert_eq!(stats.opcode_count, 6);
+        assert_eq!(stats.max_stack_depth, 3); // DUP1 increases stack depth to 3
+    }
 
-  #[test]
-  fn test_error_display() {
-    let error = StatsError::UnknownOpcode(0xFF);
-    assert_eq!(format!("{}", error), "Unknown opcode: 0xff");
-  }
+    #[test]
+    fn test_memory_operations() {
+        // PUSH1 0x20, PUSH1 0x00, MSTORE, PUSH1 0x00, MLOAD, STOP
+        let bytes = hex::decode("602060005260005100").unwrap();
+        let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
 
-  #[test]
-  fn test_stats_struct_access() {
-    let stats = Stats {
-      byte_len: 10,
-      opcode_count: 5,
-      max_stack_depth: 3,
-    };
-    
-    assert_eq!(stats.byte_len, 10);
-    assert_eq!(stats.opcode_count, 5);
-    assert_eq!(stats.max_stack_depth, 3);
-  }
+        let stats = compute_stats(&bytecode).unwrap();
+        assert_eq!(stats.byte_len, 9);
+        assert_eq!(stats.opcode_count, 6);
+        assert_eq!(stats.max_stack_depth, 2); // Max when PUSH1 values are on stack
+    }
+
+    #[test]
+    fn test_push_operations() {
+        // PUSH1 0xFF, PUSH2 0xABCD, PUSH32 (32 bytes of data), STOP
+        let mut bytes = vec![0x60, 0xFF]; // PUSH1 0xFF
+        bytes.extend_from_slice(&[0x61, 0xAB, 0xCD]); // PUSH2 0xABCD
+        bytes.push(0x7F); // PUSH32
+        bytes.extend_from_slice(&[0xFF; 32]); // 32 bytes of 0xFF
+        bytes.push(0x00); // STOP
+
+        let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
+
+        let stats = compute_stats(&bytecode).unwrap();
+        assert_eq!(stats.byte_len, 39); // 2 + 3 + 1 + 32 + 1 = 39
+        assert_eq!(stats.opcode_count, 4);
+        assert_eq!(stats.max_stack_depth, 3); // All three PUSH operations on stack
+    }
+
+    #[test]
+    fn test_arithmetic_operations() {
+        // PUSH1 0x05, PUSH1 0x03, ADD, PUSH1 0x02, MUL, STOP
+        let bytes = hex::decode("600560030160020200").unwrap();
+        let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
+
+        let stats = compute_stats(&bytecode).unwrap();
+        assert_eq!(stats.byte_len, 9);
+        assert_eq!(stats.opcode_count, 6);
+        assert_eq!(stats.max_stack_depth, 2); // Max depth when two values are on stack
+    }
+
+    #[test]
+    fn test_single_opcode() {
+        // Just STOP
+        let bytes = hex::decode("00").unwrap();
+        let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
+
+        let stats = compute_stats(&bytecode).unwrap();
+        assert_eq!(stats.byte_len, 1);
+        assert_eq!(stats.opcode_count, 1);
+        assert_eq!(stats.max_stack_depth, 0); // STOP doesn't affect stack
+    }
+
+    #[test]
+    fn test_large_bytecode() {
+        // Create a larger bytecode with many operations
+        let mut bytes = Vec::new();
+
+        // Add 20 PUSH1 operations (reduced from 50 for simpler test)
+        for i in 0..20 {
+            bytes.push(0x60); // PUSH1
+            bytes.push(i as u8); // value
+        }
+        bytes.push(0x00); // STOP
+
+        let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
+
+        let stats = compute_stats(&bytecode).unwrap();
+        assert_eq!(stats.byte_len, 41); // 20 * 2 + 1
+        assert_eq!(stats.opcode_count, 21); // 20 PUSH1s + 1 STOP
+        assert_eq!(stats.max_stack_depth, 20); // All PUSH1s accumulate on stack
+    }
+
+    #[test]
+    fn test_compute_opcode_count() {
+        let bytes = hex::decode("60FF61ABCD00").unwrap(); // PUSH1, PUSH2, STOP
+        let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
+
+        let count = compute_opcode_count(&bytecode);
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn test_get_byte_len() {
+        let bytes = hex::decode("60FF61ABCD00").unwrap();
+        let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
+
+        let len = get_byte_len(&bytecode);
+        assert_eq!(len, 6);
+    }
+
+    #[test]
+    fn test_compute_max_stack_depth() {
+        let bytes = hex::decode("60FF00").unwrap(); // PUSH1 0xFF, STOP
+        let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
+
+        let depth = compute_max_stack_depth(&bytecode).unwrap();
+        assert_eq!(depth, 1);
+    }
+
+    #[test]
+    fn test_zero_stack_depth() {
+        let bytes = hex::decode("00").unwrap(); // Just STOP
+        let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
+
+        let depth = compute_max_stack_depth(&bytecode).unwrap();
+        assert_eq!(depth, 0);
+    }
+
+    #[test]
+    fn test_error_display() {
+        let error = StatsError::UnknownOpcode(0xFF);
+        assert_eq!(format!("{}", error), "Unknown opcode: 0xff");
+    }
+
+    #[test]
+    fn test_stats_struct_access() {
+        let stats = Stats {
+            byte_len: 10,
+            opcode_count: 5,
+            max_stack_depth: 3,
+        };
+
+        assert_eq!(stats.byte_len, 10);
+        assert_eq!(stats.opcode_count, 5);
+        assert_eq!(stats.max_stack_depth, 3);
+    }
 }

--- a/crates/evm-lens-core/src/stats.rs
+++ b/crates/evm-lens-core/src/stats.rs
@@ -1,0 +1,247 @@
+use revm::{bytecode::{opcode::{OPCODE_INFO}, Bytecode}};
+
+#[derive(Debug)]
+pub struct Stats {
+  pub byte_len: usize,
+  pub opcode_count: usize,
+  pub max_stack_depth: usize
+}
+
+#[derive(Debug)]
+pub enum StatsError {
+  UnknownOpcode(u8),
+}
+
+impl std::fmt::Display for StatsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StatsError::UnknownOpcode(opcode) => {
+                write!(f, "Unknown opcode: 0x{:02x}", opcode)
+            }
+        }
+    }
+}
+
+impl std::error::Error for StatsError {}
+
+pub fn compute_stats(bytecode: &Bytecode) -> Result<Stats, StatsError> {
+  // Count the number of opcodes
+  let opcode_count = compute_opcode_count(bytecode);
+
+  // Get total byte length
+  let byte_len = get_byte_len(bytecode);
+
+  // Track PUSH / POP depth
+  let max_stack_depth = compute_max_stack_depth(bytecode)?;
+
+  Ok(Stats {
+    byte_len,
+    opcode_count,
+    max_stack_depth,
+  })
+}
+
+fn compute_opcode_count(bytecode: &Bytecode) -> usize {
+  let iter = bytecode.iter_opcodes();
+  iter.count()
+}
+
+fn get_byte_len(bytecode: &Bytecode) -> usize {
+  bytecode.bytecode().as_ref().len()
+}
+
+fn compute_max_stack_depth(bytecode: &Bytecode) -> Result<usize, StatsError> {
+  let mut iter = bytecode.iter_opcodes();
+  let mut max_depth: i32 = 0;
+  let mut depth: i32 = 0;
+
+  while let Some(opcode) = iter.peek_opcode() {
+    let opcode_info = OPCODE_INFO[opcode.get() as usize];
+
+    match opcode_info {
+      Some(opcode_info) => {
+        depth += opcode_info.io_diff() as i32;
+      }
+      None => {
+        // If the opcode is not found, it's an invalid opcode
+        return Err(StatsError::UnknownOpcode(opcode.get()));
+      }
+    }
+
+    max_depth = max_depth.max(depth);
+    iter.next();
+  }
+
+  Ok(max_depth as usize)
+}
+
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use revm::primitives::Bytes;
+
+  #[test]
+  fn test_simple_bytecode_stats() {
+    // PUSH1 0xFF, STOP
+    let bytes = hex::decode("60FF00").unwrap();
+    let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
+    
+    let stats = compute_stats(&bytecode).unwrap();
+    assert_eq!(stats.byte_len, 3);
+    assert_eq!(stats.opcode_count, 2);
+    assert_eq!(stats.max_stack_depth, 1); // PUSH1 adds 1 to stack
+  }
+
+  #[test]
+  fn test_complex_bytecode_stats() {
+    // PUSH1 0x01, PUSH1 0x02, ADD, STOP
+    let bytes = hex::decode("600160020100").unwrap();
+    let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
+    
+    let stats = compute_stats(&bytecode).unwrap();
+    assert_eq!(stats.byte_len, 6);
+    assert_eq!(stats.opcode_count, 4);
+    assert_eq!(stats.max_stack_depth, 2); // Max depth when both PUSH1s are on stack
+  }
+
+  #[test]
+  fn test_stack_operations() {
+    // PUSH1 0x01, PUSH1 0x02, DUP1, SWAP1, ADD, STOP
+    let bytes = hex::decode("6001600280900100").unwrap();
+    let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
+    
+    let stats = compute_stats(&bytecode).unwrap();
+    assert_eq!(stats.byte_len, 8);
+    assert_eq!(stats.opcode_count, 6);
+    assert_eq!(stats.max_stack_depth, 3); // DUP1 increases stack depth to 3
+  }
+
+  #[test]
+  fn test_memory_operations() {
+    // PUSH1 0x20, PUSH1 0x00, MSTORE, PUSH1 0x00, MLOAD, STOP
+    let bytes = hex::decode("602060005260005100").unwrap();
+    let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
+    
+    let stats = compute_stats(&bytecode).unwrap();
+    assert_eq!(stats.byte_len, 9);
+    assert_eq!(stats.opcode_count, 6);
+    assert_eq!(stats.max_stack_depth, 2); // Max when PUSH1 values are on stack
+  }
+
+  #[test]
+  fn test_push_operations() {
+    // PUSH1 0xFF, PUSH2 0xABCD, PUSH32 (32 bytes of data), STOP
+    let mut bytes = vec![0x60, 0xFF]; // PUSH1 0xFF
+    bytes.extend_from_slice(&[0x61, 0xAB, 0xCD]); // PUSH2 0xABCD
+    bytes.push(0x7F); // PUSH32
+    bytes.extend_from_slice(&[0xFF; 32]); // 32 bytes of 0xFF
+    bytes.push(0x00); // STOP
+    
+    let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
+    
+    let stats = compute_stats(&bytecode).unwrap();
+    assert_eq!(stats.byte_len, 39); // 2 + 3 + 1 + 32 + 1 = 39
+    assert_eq!(stats.opcode_count, 4);
+    assert_eq!(stats.max_stack_depth, 3); // All three PUSH operations on stack
+  }
+
+  #[test]
+  fn test_arithmetic_operations() {
+    // PUSH1 0x05, PUSH1 0x03, ADD, PUSH1 0x02, MUL, STOP
+    let bytes = hex::decode("600560030160020200").unwrap();
+    let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
+    
+    let stats = compute_stats(&bytecode).unwrap();
+    assert_eq!(stats.byte_len, 9);
+    assert_eq!(stats.opcode_count, 6);
+    assert_eq!(stats.max_stack_depth, 2); // Max depth when two values are on stack
+  }
+
+  #[test]
+  fn test_single_opcode() {
+    // Just STOP
+    let bytes = hex::decode("00").unwrap();
+    let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
+    
+    let stats = compute_stats(&bytecode).unwrap();
+    assert_eq!(stats.byte_len, 1);
+    assert_eq!(stats.opcode_count, 1);
+    assert_eq!(stats.max_stack_depth, 0); // STOP doesn't affect stack
+  }
+
+  #[test]
+  fn test_large_bytecode() {
+    // Create a larger bytecode with many operations
+    let mut bytes = Vec::new();
+    
+    // Add 20 PUSH1 operations (reduced from 50 for simpler test)
+    for i in 0..20 {
+      bytes.push(0x60); // PUSH1
+      bytes.push(i as u8); // value
+    }
+    bytes.push(0x00); // STOP
+    
+    let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
+    
+    let stats = compute_stats(&bytecode).unwrap();
+    assert_eq!(stats.byte_len, 41); // 20 * 2 + 1
+    assert_eq!(stats.opcode_count, 21); // 20 PUSH1s + 1 STOP
+    assert_eq!(stats.max_stack_depth, 20); // All PUSH1s accumulate on stack
+  }
+
+  #[test]
+  fn test_compute_opcode_count() {
+    let bytes = hex::decode("60FF61ABCD00").unwrap(); // PUSH1, PUSH2, STOP
+    let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
+    
+    let count = compute_opcode_count(&bytecode);
+    assert_eq!(count, 3);
+  }
+
+  #[test]
+  fn test_get_byte_len() {
+    let bytes = hex::decode("60FF61ABCD00").unwrap();
+    let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
+    
+    let len = get_byte_len(&bytecode);
+    assert_eq!(len, 6);
+  }
+
+  #[test]
+  fn test_compute_max_stack_depth() {
+    let bytes = hex::decode("60FF00").unwrap(); // PUSH1 0xFF, STOP
+    let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
+    
+    let depth = compute_max_stack_depth(&bytecode).unwrap();
+    assert_eq!(depth, 1);
+  }
+
+  #[test]
+  fn test_zero_stack_depth() {
+    let bytes = hex::decode("00").unwrap(); // Just STOP
+    let bytecode = Bytecode::new_raw_checked(Bytes::from(bytes)).unwrap();
+    
+    let depth = compute_max_stack_depth(&bytecode).unwrap();
+    assert_eq!(depth, 0);
+  }
+
+  #[test]
+  fn test_error_display() {
+    let error = StatsError::UnknownOpcode(0xFF);
+    assert_eq!(format!("{}", error), "Unknown opcode: 0xff");
+  }
+
+  #[test]
+  fn test_stats_struct_access() {
+    let stats = Stats {
+      byte_len: 10,
+      opcode_count: 5,
+      max_stack_depth: 3,
+    };
+    
+    assert_eq!(stats.byte_len, 10);
+    assert_eq!(stats.opcode_count, 5);
+    assert_eq!(stats.max_stack_depth, 3);
+  }
+}

--- a/crates/evm-lens/src/main.rs
+++ b/crates/evm-lens/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use colored::*;
-use evm_lens_core::{disassemble, get_stats, Stats};
+use evm_lens_core::{Stats, disassemble, get_stats};
 use io::Source;
 
 mod io;
@@ -58,10 +58,7 @@ struct Args {
     )]
     rpc: Option<String>,
 
-    #[arg(
-        long,
-        help = "Show bytecode statistics after disassembly"
-    )]
+    #[arg(long, help = "Show bytecode statistics after disassembly")]
     stats: bool,
 }
 
@@ -227,7 +224,11 @@ async fn main() -> color_eyre::Result<()> {
     if args.stats {
         println!();
         match get_stats(&bytes) {
-            Ok(Stats { byte_len, opcode_count, max_stack_depth }) => {
+            Ok(Stats {
+                byte_len,
+                opcode_count,
+                max_stack_depth,
+            }) => {
                 println!("{}", "BYTECODE STATISTICS".bright_blue().bold());
                 println!("{}", "=".repeat(50).bright_black());
                 println!("Byte length: {}", byte_len);


### PR DESCRIPTION
Add `--stats` flag to generate brief summary of opcodes 