### PR TITLE
chore: bump workspace to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "evm-lens"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "evm-lens-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/evm-lens-core", "crates/evm-lens"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.2"
+version = "0.2.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/andyrobert3/evm-lens"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ cargo install evm-lens
 
 ```toml
 [dependencies]
-evm-lens-core = "0.1.2"
+evm-lens-core = "2.0.0"
 ```
 
 ### Example Usage

--- a/crates/evm-lens/Cargo.toml
+++ b/crates/evm-lens/Cargo.toml
@@ -20,7 +20,7 @@ colored.workspace = true
 clap.workspace = true
 color-eyre.workspace = true
 hex.workspace = true
-evm-lens-core = { version = "0.1.2", path = "../evm-lens-core" }
+evm-lens-core = { version = "0.2.0", path = "../evm-lens-core" }
 # I/O module dependencies
 tokio.workspace = true
 serde.workspace = true


### PR DESCRIPTION
workspace cargo crate bump