### PR TITLE
feat: add heuristic resolver for storage-diff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,6 +1282,7 @@ name = "evm-lens-core"
 version = "0.2.0"
 dependencies = [
  "async-trait",
+ "color-eyre",
  "dirs",
  "hex",
  "log",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ cargo install evm-lens
 
 ```toml
 [dependencies]
-evm-lens-core = "2.0.0"
+evm-lens-core = "3.0.0"
 ```
 
 ### Example Usage

--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ evm-lens 60FF61ABCD00 --stats
 
 # Decode function selectors with ABI resolution
 evm-lens 63a9059cbb00 --abi
+
+# Compare storage layouts (files only)
+evm-lens storage-diff artifacts/old.hex artifacts/new.hex
+evm-lens storage-diff old.hex new.hex --json target/storage.json --html target/storage.html
+evm-lens storage-diff old.hex new.hex --ci
 ```
 
 **Library:**
@@ -80,6 +85,7 @@ for (position, opcode) in ops {
 - **🔍 Disassemble EVM bytecode** from multiple sources - hex strings, files, stdin, and live contract addresses
 - **📊 Generate statistics summary** including bytecode length, number of opcodes, and maximum stack depth
 - **🎯 Decode function selectors** - automatically resolve PUSH4 instructions to human-readable function signatures using 4byte.directory
+- **🧮 Storage diff** - compare two artifacts and flag storage layout changes with JSON/HTML reports and CI-friendly exit codes
 
 
 
@@ -129,6 +135,41 @@ evm-lens --address 0x123... --rpc https://eth.llamarpc.com --abi
 
 # Combine with stats for comprehensive analysis
 evm-lens 63a9059cbb00 --abi --stats
+```
+
+
+## 🧮 Storage Diff
+
+Compare two compiled artifacts (files containing hex-encoded runtime bytecode) and flag storage layout risks.
+
+```bash
+evm-lens storage-diff <old.hex> <new.hex> [--json out.json] [--html out.html] [--ci]
+```
+
+- Inputs:
+  - `<old.hex>`, `<new.hex>`: file paths containing hex-encoded runtime bytecode (with or without 0x).
+- How it works:
+  - Builds a StorageLayout for each input using a composite resolver:
+    1) Compiler metadata (if available), 2) conservative bytecode heuristic (PUSH… then SLOAD/SSTORE).
+  - Computes a per-slot diff with statuses: `Same | Added | Removed | TypeChanged | PackingChanged`.
+  - Assigns grades: `Ok | Risk | Break` (Added=Ok, Removed/TypeChanged=Break, PackingChanged=Risk).
+  - Records provenance per side: `CompilerMetadata` or `HeuristicTrace`.
+- Outputs:
+  - CLI one-line summary with counts and max grade.
+  - Optional JSON (`--json`) and HTML (`--html`) reports.
+- CI:
+  - With `--ci`, exits non‑zero (code 2) if `max_grade >= Risk`.
+
+Examples:
+```bash
+# Basic compare
+evm-lens storage-diff artifacts/old.hex artifacts/new.hex
+
+# Write JSON/HTML reports
+evm-lens storage-diff old.hex new.hex --json target/storage.json --html target/storage.html
+
+# CI policy (non-zero on Risk/Break)
+evm-lens storage-diff old.hex new.hex --ci
 ```
 
 

--- a/crates/evm-lens-core/Cargo.toml
+++ b/crates/evm-lens-core/Cargo.toml
@@ -23,6 +23,7 @@ async-trait.workspace = true
 thiserror.workspace = true
 log.workspace = true
 dirs.workspace = true
+color-eyre.workspace = true
 
 [dev-dependencies]
 mockito.workspace = true

--- a/crates/evm-lens-core/src/lib.rs
+++ b/crates/evm-lens-core/src/lib.rs
@@ -3,6 +3,7 @@ use revm::{bytecode::Bytecode, primitives::Bytes};
 pub mod stats;
 pub use stats::{Stats, StatsError, compute_stats};
 pub mod abi;
+pub mod storage;
 
 // Re-export OpCode for public use
 pub use revm::bytecode::OpCode;

--- a/crates/evm-lens-core/src/storage/diff.rs
+++ b/crates/evm-lens-core/src/storage/diff.rs
@@ -1,0 +1,276 @@
+use serde::{Deserialize, Serialize};
+
+use super::layout::{Provenance, StorageEntry, StorageLayout, StorageType};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum DiffStatus {
+    Same,
+    Added,
+    Removed,
+    TypeChanged,
+    PackingChanged,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SeverityGrade {
+    Ok,
+    Risk,
+    Break,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DiffEntry {
+    pub slot: u128,
+    pub old: Option<StorageEntry>,
+    pub new: Option<StorageEntry>,
+    pub status: DiffStatus,
+    pub grade: SeverityGrade,
+    pub provenance_old: Option<Provenance>,
+    pub provenance_new: Option<Provenance>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Summary {
+    pub added: usize,
+    pub removed: usize,
+    pub type_changed: usize,
+    pub packing_changed: usize,
+    pub same: usize,
+    pub max_grade: SeverityGrade,
+}
+
+fn grade_for(status: &DiffStatus) -> SeverityGrade {
+    match status {
+        DiffStatus::Same => SeverityGrade::Ok,
+        DiffStatus::Added => SeverityGrade::Ok,
+        DiffStatus::Removed => SeverityGrade::Break,
+        DiffStatus::TypeChanged => SeverityGrade::Break,
+        DiffStatus::PackingChanged => SeverityGrade::Risk,
+    }
+}
+
+fn is_same_type(a: &StorageType, b: &StorageType) -> bool {
+    a == b
+}
+
+fn packing_key(e: &StorageEntry) -> (Option<u8>, Option<u8>) {
+    (e.offset, e.size)
+}
+
+pub fn diff_layouts(old: &StorageLayout, new: &StorageLayout) -> (Vec<DiffEntry>, Summary) {
+    // Group by slot, keeping a single representative per slot for conservative policy.
+    // If multiple packed fields exist, we compare by type and packing attributes; if any differ, mark PackingChanged.
+
+    use std::collections::BTreeMap;
+
+    let mut old_map: BTreeMap<u128, Vec<&StorageEntry>> = BTreeMap::new();
+    for e in &old.entries {
+        old_map.entry(e.slot).or_default().push(e);
+    }
+
+    let mut new_map: BTreeMap<u128, Vec<&StorageEntry>> = BTreeMap::new();
+    for e in &new.entries {
+        new_map.entry(e.slot).or_default().push(e);
+    }
+
+    let mut all_slots: BTreeMap<u128, ()> = BTreeMap::new();
+    for s in old_map.keys() {
+        all_slots.insert(*s, ());
+    }
+    for s in new_map.keys() {
+        all_slots.insert(*s, ());
+    }
+
+    let mut diffs: Vec<DiffEntry> = Vec::new();
+    let mut summary = Summary {
+        added: 0,
+        removed: 0,
+        type_changed: 0,
+        packing_changed: 0,
+        same: 0,
+        max_grade: SeverityGrade::Ok,
+    };
+
+    for slot in all_slots.keys().copied() {
+        let old_entries = old_map.get(&slot).cloned().unwrap_or_default();
+        let new_entries = new_map.get(&slot).cloned().unwrap_or_default();
+
+        let status = match (old_entries.is_empty(), new_entries.is_empty()) {
+            (true, false) => DiffStatus::Added,
+            (false, true) => DiffStatus::Removed,
+            (true, true) => continue,
+            (false, false) => {
+                // Compare conservatively
+                // If any type differs across matched pairs, TypeChanged.
+                // Else if packing differs (offset/size counts differ), PackingChanged.
+                let mut type_changed = false;
+                let mut packing_changed = false;
+
+                let min_len = old_entries.len().min(new_entries.len());
+                for i in 0..min_len {
+                    if !is_same_type(&old_entries[i].r#type, &new_entries[i].r#type) {
+                        type_changed = true;
+                        break;
+                    }
+                    if packing_key(old_entries[i]) != packing_key(new_entries[i]) {
+                        packing_changed = true;
+                    }
+                }
+                if !type_changed {
+                    if old_entries.len() != new_entries.len() {
+                        packing_changed = true;
+                    }
+                }
+
+                if type_changed {
+                    DiffStatus::TypeChanged
+                } else if packing_changed {
+                    DiffStatus::PackingChanged
+                } else {
+                    DiffStatus::Same
+                }
+            }
+        };
+
+        let grade = grade_for(&status);
+        summary.max_grade = summary.max_grade.max(grade);
+        match status {
+            DiffStatus::Same => summary.same += 1,
+            DiffStatus::Added => summary.added += 1,
+            DiffStatus::Removed => summary.removed += 1,
+            DiffStatus::TypeChanged => summary.type_changed += 1,
+            DiffStatus::PackingChanged => summary.packing_changed += 1,
+        }
+
+        let old_rep = old_entries.first().cloned().cloned();
+        let new_rep = new_entries.first().cloned().cloned();
+
+        diffs.push(DiffEntry {
+            slot,
+            old: old_rep.clone(),
+            new: new_rep.clone(),
+            status,
+            grade,
+            provenance_old: old_rep.as_ref().map(|e| e.provenance),
+            provenance_new: new_rep.as_ref().map(|e| e.provenance),
+        });
+    }
+
+    (diffs, summary)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(
+        slot: u128,
+        ty: StorageType,
+        offset: Option<u8>,
+        size: Option<u8>,
+        prov: Provenance,
+    ) -> StorageEntry {
+        StorageEntry {
+            slot,
+            offset,
+            size,
+            r#type: ty,
+            label: None,
+            provenance: prov,
+        }
+    }
+
+    #[test]
+    fn added_and_removed() {
+        let old = StorageLayout {
+            entries: vec![entry(
+                0,
+                StorageType::Unknown,
+                None,
+                None,
+                Provenance::HeuristicTrace,
+            )],
+        };
+        let new = StorageLayout {
+            entries: vec![entry(
+                1,
+                StorageType::Unknown,
+                None,
+                None,
+                Provenance::HeuristicTrace,
+            )],
+        };
+        let (_diffs, summary) = diff_layouts(&old, &new);
+        assert_eq!(summary.added, 1);
+        assert_eq!(summary.removed, 1);
+        assert_eq!(summary.max_grade, SeverityGrade::Break);
+    }
+
+    #[test]
+    fn type_changed_breaks() {
+        let old = StorageLayout {
+            entries: vec![entry(
+                0,
+                StorageType::Uint { bits: 256 },
+                None,
+                None,
+                Provenance::CompilerMetadata,
+            )],
+        };
+        let new = StorageLayout {
+            entries: vec![entry(
+                0,
+                StorageType::Address,
+                None,
+                None,
+                Provenance::CompilerMetadata,
+            )],
+        };
+        let (_diffs, summary) = diff_layouts(&old, &new);
+        assert_eq!(summary.type_changed, 1);
+        assert_eq!(summary.max_grade, SeverityGrade::Break);
+    }
+
+    #[test]
+    fn packing_changed_risk() {
+        let old = StorageLayout {
+            entries: vec![entry(
+                0,
+                StorageType::Uint { bits: 256 },
+                Some(0),
+                Some(32),
+                Provenance::CompilerMetadata,
+            )],
+        };
+        let new = StorageLayout {
+            entries: vec![entry(
+                0,
+                StorageType::Uint { bits: 256 },
+                Some(1),
+                Some(31),
+                Provenance::CompilerMetadata,
+            )],
+        };
+        let (_diffs, summary) = diff_layouts(&old, &new);
+        assert_eq!(summary.packing_changed, 1);
+        assert_eq!(summary.max_grade, SeverityGrade::Risk);
+    }
+
+    #[test]
+    fn same_ok() {
+        let e = entry(
+            2,
+            StorageType::Bool,
+            None,
+            None,
+            Provenance::CompilerMetadata,
+        );
+        let old = StorageLayout {
+            entries: vec![e.clone()],
+        };
+        let new = StorageLayout { entries: vec![e] };
+        let (_diffs, summary) = diff_layouts(&old, &new);
+        assert_eq!(summary.same, 1);
+        assert_eq!(summary.max_grade, SeverityGrade::Ok);
+    }
+}

--- a/crates/evm-lens-core/src/storage/layout.rs
+++ b/crates/evm-lens-core/src/storage/layout.rs
@@ -1,0 +1,57 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum Provenance {
+    CompilerMetadata,
+    HeuristicTrace,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum StorageType {
+    /// Unknown or not confidently inferred
+    Unknown,
+    /// Basic solidity-like types (conservative)
+    Uint {
+        bits: u16,
+    },
+    Int {
+        bits: u16,
+    },
+    Bool,
+    Address,
+    BytesFixed {
+        size: u8,
+    },
+    BytesDynamic,
+    String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StorageEntry {
+    pub slot: u128,
+    /// Optional byte offset for packed fields (0..31). If None, occupies full slot.
+    pub offset: Option<u8>,
+    /// Size in bytes if known when packed; None for full slot/unknown.
+    pub size: Option<u8>,
+    pub r#type: StorageType,
+    pub label: Option<String>,
+    pub provenance: Provenance,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StorageLayout {
+    /// Map by slot to entries (supports packed fields).
+    pub entries: Vec<StorageEntry>,
+}
+
+impl StorageLayout {
+    pub fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+        }
+    }
+
+    pub fn add_entry(&mut self, entry: StorageEntry) {
+        self.entries.push(entry);
+    }
+}

--- a/crates/evm-lens-core/src/storage/mod.rs
+++ b/crates/evm-lens-core/src/storage/mod.rs
@@ -1,0 +1,8 @@
+pub mod diff;
+pub mod layout;
+pub mod resolver;
+pub mod resolvers;
+
+pub use diff::{DiffEntry, DiffStatus, SeverityGrade, Summary, diff_layouts};
+pub use layout::{Provenance, StorageEntry, StorageLayout, StorageType};
+pub use resolver::CompositeResolver;

--- a/crates/evm-lens-core/src/storage/resolver.rs
+++ b/crates/evm-lens-core/src/storage/resolver.rs
@@ -1,0 +1,29 @@
+use async_trait::async_trait;
+
+use super::layout::StorageLayout;
+
+#[async_trait]
+pub trait StorageLayoutResolver: Send + Sync {
+    async fn resolve(&self, input: &[u8]) -> color_eyre::Result<Option<StorageLayout>>;
+}
+
+/// Composite resolver that tries multiple resolvers in order and returns the first non-None
+/// layout. If none succeed, returns an empty layout.
+pub struct CompositeResolver {
+    resolvers: Vec<Box<dyn StorageLayoutResolver>>,
+}
+
+impl CompositeResolver {
+    pub fn new(resolvers: Vec<Box<dyn StorageLayoutResolver>>) -> Self {
+        Self { resolvers }
+    }
+
+    pub async fn resolve(&self, input: &[u8]) -> color_eyre::Result<StorageLayout> {
+        for r in &self.resolvers {
+            if let Some(l) = r.resolve(input).await? {
+                return Ok(l);
+            }
+        }
+        Ok(StorageLayout::new())
+    }
+}

--- a/crates/evm-lens-core/src/storage/resolvers/heuristic.rs
+++ b/crates/evm-lens-core/src/storage/resolvers/heuristic.rs
@@ -1,0 +1,179 @@
+use async_trait::async_trait;
+use revm::bytecode::OpCode;
+
+use crate::disassemble;
+use crate::storage::layout::{Provenance, StorageEntry, StorageLayout, StorageType};
+use crate::storage::resolver::StorageLayoutResolver;
+
+/// Heuristic that scans for PUSH <const> followed by SLOAD/SSTORE.
+/// If found, treat the const as a direct slot index. Types are Unknown.
+pub struct HeuristicResolver;
+
+#[async_trait]
+impl StorageLayoutResolver for HeuristicResolver {
+    async fn resolve(&self, input: &[u8]) -> color_eyre::Result<Option<StorageLayout>> {
+        if input.is_empty() {
+            return Ok(Some(StorageLayout::new()));
+        }
+
+        let ops = match disassemble(input) {
+            Ok(v) => v,
+            Err(_) => return Ok(Some(StorageLayout::new())),
+        };
+
+        let mut layout = StorageLayout::new();
+
+        // Windowed scan: PUSH[1..32] followed within small window by SLOAD/SSTORE
+        let window = 6usize;
+
+        for (idx, (_pos, op)) in ops.iter().enumerate() {
+            let push_n = match *op {
+                OpCode::PUSH0 => Some(0u8),
+                OpCode::PUSH1 => Some(1),
+                OpCode::PUSH2 => Some(2),
+                OpCode::PUSH3 => Some(3),
+                OpCode::PUSH4 => Some(4),
+                OpCode::PUSH5 => Some(5),
+                OpCode::PUSH6 => Some(6),
+                OpCode::PUSH7 => Some(7),
+                OpCode::PUSH8 => Some(8),
+                OpCode::PUSH9 => Some(9),
+                OpCode::PUSH10 => Some(10),
+                OpCode::PUSH11 => Some(11),
+                OpCode::PUSH12 => Some(12),
+                OpCode::PUSH13 => Some(13),
+                OpCode::PUSH14 => Some(14),
+                OpCode::PUSH15 => Some(15),
+                OpCode::PUSH16 => Some(16),
+                OpCode::PUSH17 => Some(17),
+                OpCode::PUSH18 => Some(18),
+                OpCode::PUSH19 => Some(19),
+                OpCode::PUSH20 => Some(20),
+                OpCode::PUSH21 => Some(21),
+                OpCode::PUSH22 => Some(22),
+                OpCode::PUSH23 => Some(23),
+                OpCode::PUSH24 => Some(24),
+                OpCode::PUSH25 => Some(25),
+                OpCode::PUSH26 => Some(26),
+                OpCode::PUSH27 => Some(27),
+                OpCode::PUSH28 => Some(28),
+                OpCode::PUSH29 => Some(29),
+                OpCode::PUSH30 => Some(30),
+                OpCode::PUSH31 => Some(31),
+                OpCode::PUSH32 => Some(32),
+                _ => None,
+            };
+
+            if push_n.is_none() {
+                continue;
+            }
+
+            // Look ahead up to `window` ops for SLOAD/SSTORE as a conservative signal
+            let mut found = false;
+            for j in 1..=window {
+                if let Some((_, next_op)) = ops.get(idx + j) {
+                    match *next_op {
+                        OpCode::SLOAD | OpCode::SSTORE => {
+                            found = true;
+                            break;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            if !found {
+                continue;
+            }
+
+            // Extract pushed immediate as big-endian integer from underlying byte slice.
+            // We conservatively re-scan input bytes at the recorded opcode position to get immediates.
+            // For v0.3 simplicity, we approximate by reading from the raw hex window preceding the op.
+            let (pos, _op) = ops[idx];
+            // The immediate begins at pos+1 and spans push_n bytes; guard bounds.
+            let n = push_n.unwrap() as usize;
+            if pos + 1 + n > input.len() {
+                continue;
+            }
+            let imm = &input[pos + 1..pos + 1 + n];
+            // Convert to u128 if fits; skip otherwise
+            if n > 16 {
+                continue;
+            }
+            let mut slot: u128 = 0;
+            // Shift left by 8 bits for each byte
+            for &b in imm {
+                slot = (slot << 8) | b as u128;
+            }
+
+            // Deduplicate per slot
+            if layout.entries.iter().any(|e| e.slot == slot) {
+                continue;
+            }
+            layout.add_entry(StorageEntry {
+                slot,
+                offset: None,
+                size: None,
+                r#type: StorageType::Unknown,
+                label: None,
+                provenance: Provenance::HeuristicTrace,
+            });
+        }
+
+        Ok(Some(layout))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn detects_push1_followed_by_sload() {
+        // 60 00 54 00 => PUSH1 0x00; SLOAD; STOP
+        let resolver = HeuristicResolver;
+        let bytes = hex::decode("60005400").unwrap();
+        let layout = resolver.resolve(&bytes).await.unwrap().unwrap();
+        assert_eq!(layout.entries.len(), 1);
+        assert_eq!(layout.entries[0].slot, 0);
+    }
+
+    #[tokio::test]
+    async fn detects_push2_followed_by_sstore() {
+        // 61 ab cd 55 00 => PUSH2 0xABCD; SSTORE; STOP
+        let resolver = HeuristicResolver;
+        let bytes = hex::decode("61abcd5500").unwrap();
+        let layout = resolver.resolve(&bytes).await.unwrap().unwrap();
+        assert_eq!(layout.entries.len(), 1);
+        assert_eq!(layout.entries[0].slot, 0xABCD);
+    }
+
+    #[tokio::test]
+    async fn no_detection_beyond_window() {
+        // PUSH1 0x00, then 7 non-storage ops (DUP1), then SLOAD => beyond window=6
+        // 60 00 80 80 80 80 80 80 80 54 00
+        let resolver = HeuristicResolver;
+        let bytes = hex::decode("6000808080808080805400").unwrap();
+        let layout = resolver.resolve(&bytes).await.unwrap().unwrap();
+        assert_eq!(layout.entries.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn dedup_same_slot_multiple_occurrences() {
+        // PUSH1 0x01; SLOAD; PUSH1 0x01; SSTORE; STOP
+        // 60 01 54 60 01 55 00
+        let resolver = HeuristicResolver;
+        let bytes = hex::decode("60015460015500").unwrap();
+        let layout = resolver.resolve(&bytes).await.unwrap().unwrap();
+        assert_eq!(layout.entries.len(), 1);
+        assert_eq!(layout.entries[0].slot, 1);
+    }
+
+    #[tokio::test]
+    async fn skip_push32_immediate() {
+        // 7f followed by 32 bytes of 0x00, then SLOAD => n>16 should skip
+        let resolver = HeuristicResolver;
+        let bytes = hex::decode(&format!("7f{}54", "00".repeat(32))).unwrap();
+        let layout = resolver.resolve(&bytes).await.unwrap().unwrap();
+        assert_eq!(layout.entries.len(), 0);
+    }
+}

--- a/crates/evm-lens-core/src/storage/resolvers/metadata.rs
+++ b/crates/evm-lens-core/src/storage/resolvers/metadata.rs
@@ -1,0 +1,32 @@
+use async_trait::async_trait;
+
+use crate::storage::layout::{Provenance, StorageEntry, StorageLayout, StorageType};
+use crate::storage::resolver::StorageLayoutResolver;
+
+/// Minimal placeholder for a metadata-based resolver.
+/// v0.3 aims for conservative approach: try to parse embedded metadata if present.
+pub struct MetadataResolver;
+
+#[async_trait]
+impl StorageLayoutResolver for MetadataResolver {
+    async fn resolve(&self, _input: &[u8]) -> color_eyre::Result<Option<StorageLayout>> {
+        // For v0.3.0, we keep this minimal. Real implementation would attempt to decode
+        // compiler metadata and extract storage layout. Returning None means fallback.
+        let _ = _input;
+        Ok(None)
+    }
+}
+
+#[allow(dead_code)]
+fn layout_from_metadata_example() -> StorageLayout {
+    let mut l = StorageLayout::new();
+    l.add_entry(StorageEntry {
+        slot: 0,
+        offset: None,
+        size: None,
+        r#type: StorageType::Uint { bits: 256 },
+        label: Some("example".to_string()),
+        provenance: Provenance::CompilerMetadata,
+    });
+    l
+}

--- a/crates/evm-lens-core/src/storage/resolvers/mod.rs
+++ b/crates/evm-lens-core/src/storage/resolvers/mod.rs
@@ -1,0 +1,2 @@
+pub mod heuristic;
+pub mod metadata;

--- a/crates/evm-lens/src/main.rs
+++ b/crates/evm-lens/src/main.rs
@@ -1,17 +1,23 @@
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use colored::*;
+use evm_lens_core::storage::{
+    CompositeResolver, SeverityGrade, diff_layouts,
+    resolvers::{heuristic::HeuristicResolver, metadata::MetadataResolver},
+};
 use evm_lens_core::{Stats, disassemble, get_stats};
 use io::Source;
+use std::path::PathBuf;
 
 mod abi_resolver;
 mod io;
 mod opcode;
+mod report;
 
 #[derive(Parser)]
 #[command(
     name = "evm-lens",
     version,
-    about = "A colorful EVM bytecode disassembler",
+    about = "A colorful EVM bytecode disassembler and storage diff tool",
     after_help = "EXAMPLES:
     evm-lens 60FF                              # Simple PUSH1 instruction from arg
     echo '0x60FF61ABCD00' | evm-lens --stdin   # From stdin
@@ -19,10 +25,13 @@ mod opcode;
     evm-lens --address 0x... --rpc http://...  # From blockchain
     evm-lens 60FF61ABCD00 --stats              # Show disassembly + statistics
     evm-lens 60FF61ABCD00 --abi                # Show disassembly + 4byte signatures
+    evm-lens storage-diff <old.hex> <new.hex> [--json out.json] [--html out.html] [--ci]
 
 For more information, visit: https://github.com/andyrobert3/evm-lens"
 )]
 struct Args {
+    #[command(subcommand)]
+    command: Option<Command>,
     #[arg(
         help = "Hexadecimal EVM bytecode to disassemble (if no other source specified)",
         value_name = "BYTECODE",
@@ -66,6 +75,29 @@ struct Args {
 
     #[arg(long, help = "Resolve 4-byte selectors to function signatures")]
     abi: bool,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Compare two files (hex contents) and report storage layout diffs
+    StorageDiff(StorageDiffArgs),
+}
+
+#[derive(clap::Args)]
+struct StorageDiffArgs {
+    /// Old artifact file path containing hex-encoded runtime bytecode
+    old: PathBuf,
+    /// New artifact file path containing hex-encoded runtime bytecode
+    new: PathBuf,
+    /// Output JSON file path
+    #[arg(long, value_name = "FILE")]
+    json: Option<PathBuf>,
+    /// Output HTML file path
+    #[arg(long, value_name = "FILE")]
+    html: Option<PathBuf>,
+    /// CI mode: exit non-zero on Risk/Break
+    #[arg(long)]
+    ci: bool,
 }
 
 fn print_header() {
@@ -195,6 +227,14 @@ async fn main() -> color_eyre::Result<()> {
 
     let args = Args::parse();
 
+    if let Some(Command::StorageDiff(sd)) = &args.command {
+        if let Err(e) = run_storage_diff(sd).await {
+            print_error(&format!("{}", e));
+            std::process::exit(1);
+        }
+        return Ok(());
+    }
+
     let bytes = match get_bytes_from_args(&args).await {
         Ok(bytes) => bytes,
         Err(e) => {
@@ -211,4 +251,67 @@ async fn main() -> color_eyre::Result<()> {
     }
 
     Ok(())
+}
+
+async fn run_storage_diff(sd: &StorageDiffArgs) -> color_eyre::Result<()> {
+    let old_bytes = load_bytes_from_file(&sd.old).await?;
+    let new_bytes = load_bytes_from_file(&sd.new).await?;
+
+    let resolver = CompositeResolver::new(vec![
+        Box::new(MetadataResolver),
+        Box::new(HeuristicResolver),
+    ]);
+
+    let old_layout = resolver.resolve(&old_bytes).await?;
+    let new_layout = resolver.resolve(&new_bytes).await?;
+
+    let (diffs, summary) = diff_layouts(&old_layout, &new_layout);
+
+    // CLI summary line
+    println!(
+        "{} {}={} {}={} {}={} {}={} {}={} {}={}",
+        "storage-diff:".bright_blue().bold(),
+        "added".bright_green(),
+        summary.added,
+        "removed".bright_red(),
+        summary.removed,
+        "type_changed".bright_red(),
+        summary.type_changed,
+        "packing_changed".bright_yellow(),
+        summary.packing_changed,
+        "same".bright_black(),
+        summary.same,
+        "max_grade".bright_white(),
+        format!("{:?}", summary.max_grade)
+    );
+
+    if let Some(path) = &sd.json {
+        report::write_json_report(path, &diffs, &summary)?;
+        println!("{} {}", "wrote".bright_black(), path.display());
+    }
+    if let Some(path) = &sd.html {
+        report::write_html_report(path, &diffs, &summary)?;
+        println!("{} {}", "wrote".bright_black(), path.display());
+    }
+
+    if sd.ci {
+        if summary.max_grade >= SeverityGrade::Risk {
+            std::process::exit(2);
+        }
+    }
+
+    Ok(())
+}
+
+async fn load_bytes_from_file(path: &PathBuf) -> color_eyre::Result<Vec<u8>> {
+    use std::fs;
+    if !path.exists() || !path.is_file() {
+        return Err(color_eyre::eyre::eyre!(
+            "File not found or not a file: {}",
+            path.display()
+        ));
+    }
+    let content = fs::read_to_string(path)
+        .map_err(|e| color_eyre::eyre::eyre!("Failed to read file {}: {}", path.display(), e))?;
+    io::decode_hex(content.trim())
 }

--- a/crates/evm-lens/src/report.rs
+++ b/crates/evm-lens/src/report.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::path::Path;
 
 use color_eyre::Result;
-use evm_lens_core::storage::{DiffEntry, SeverityGrade, Summary, Provenance, StorageType};
+use evm_lens_core::storage::{DiffEntry, Provenance, SeverityGrade, StorageType, Summary};
 use serde::Serialize;
 
 #[derive(Serialize)]
@@ -31,8 +31,22 @@ pub fn write_html_report(path: &Path, diffs: &[DiffEntry], summary: &Summary) ->
     )?;
     writeln!(f, "</head><body>")?;
     writeln!(f, "<h2>Storage Diff</h2>")?;
-    let max_grade_class = match summary.max_grade { SeverityGrade::Ok => "ok", SeverityGrade::Risk => "risk", SeverityGrade::Break => "break" };
-    writeln!(f, "<p>Added: {} &nbsp; Removed: {} &nbsp; TypeChanged: {} &nbsp; PackingChanged: {} &nbsp; Same: {} &nbsp; Max grade: <span class=\"chip {}\">{:?}</span></p>", summary.added, summary.removed, summary.type_changed, summary.packing_changed, summary.same, max_grade_class, summary.max_grade)?;
+    let max_grade_class = match summary.max_grade {
+        SeverityGrade::Ok => "ok",
+        SeverityGrade::Risk => "risk",
+        SeverityGrade::Break => "break",
+    };
+    writeln!(
+        f,
+        "<p>Added: {} &nbsp; Removed: {} &nbsp; TypeChanged: {} &nbsp; PackingChanged: {} &nbsp; Same: {} &nbsp; Max grade: <span class=\"chip {}\">{:?}</span></p>",
+        summary.added,
+        summary.removed,
+        summary.type_changed,
+        summary.packing_changed,
+        summary.same,
+        max_grade_class,
+        summary.max_grade
+    )?;
 
     writeln!(f, "<table>")?;
     writeln!(
@@ -46,21 +60,39 @@ pub fn write_html_report(path: &Path, diffs: &[DiffEntry], summary: &Summary) ->
             SeverityGrade::Break => "break",
         };
         let (old_desc, old_unknown) = match d.old.as_ref() {
-            Some(e) => (format!("{:?}", e.r#type), matches!(e.r#type, StorageType::Unknown)),
+            Some(e) => (
+                format!("{:?}", e.r#type),
+                matches!(e.r#type, StorageType::Unknown),
+            ),
             None => ("—".to_string(), false),
         };
         let (new_desc, new_unknown) = match d.new.as_ref() {
-            Some(e) => (format!("{:?}", e.r#type), matches!(e.r#type, StorageType::Unknown)),
+            Some(e) => (
+                format!("{:?}", e.r#type),
+                matches!(e.r#type, StorageType::Unknown),
+            ),
             None => ("—".to_string(), false),
         };
         let tip = "No compiler metadata available; conservative heuristic left type unknown.";
-        let old_html = if old_unknown { format!("<span title=\"{}\">{}</span>", tip, old_desc) } else { old_desc };
-        let new_html = if new_unknown { format!("<span title=\"{}\">{}</span>", tip, new_desc) } else { new_desc };
+        let old_html = if old_unknown {
+            format!("<span title=\"{}\">{}</span>", tip, old_desc)
+        } else {
+            old_desc
+        };
+        let new_html = if new_unknown {
+            format!("<span title=\"{}\">{}</span>", tip, new_desc)
+        } else {
+            new_desc
+        };
 
         let badge = |p: Option<Provenance>| -> String {
             match p {
-                Some(Provenance::CompilerMetadata) => "<span class=\"badge meta\">Metadata</span>".to_string(),
-                Some(Provenance::HeuristicTrace) => "<span class=\"badge heur\">Heuristic</span>".to_string(),
+                Some(Provenance::CompilerMetadata) => {
+                    "<span class=\"badge meta\">Metadata</span>".to_string()
+                }
+                Some(Provenance::HeuristicTrace) => {
+                    "<span class=\"badge heur\">Heuristic</span>".to_string()
+                }
                 None => "—".to_string(),
             }
         };

--- a/crates/evm-lens/src/report.rs
+++ b/crates/evm-lens/src/report.rs
@@ -1,0 +1,78 @@
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+use color_eyre::Result;
+use evm_lens_core::storage::{DiffEntry, SeverityGrade, Summary, Provenance, StorageType};
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct JsonReport<'a> {
+    diffs: &'a [DiffEntry],
+    summary: &'a Summary,
+}
+
+pub fn write_json_report(path: &Path, diffs: &[DiffEntry], summary: &Summary) -> Result<()> {
+    let report = JsonReport { diffs, summary };
+    let json = serde_json::to_string_pretty(&report)?;
+    std::fs::write(path, json)?;
+    Ok(())
+}
+
+pub fn write_html_report(path: &Path, diffs: &[DiffEntry], summary: &Summary) -> Result<()> {
+    let mut f = File::create(path)?;
+    writeln!(
+        f,
+        "<html><head><meta charset=\"utf-8\"><title>evm-lens storage diff</title>"
+    )?;
+    writeln!(
+        f,
+        "<style>body{{font-family:system-ui,Arial,sans-serif}} table{{border-collapse:collapse;width:100%}} th,td{{border:1px solid #ddd;padding:6px}} th{{background:#f5f5f5;text-align:left;position:sticky;top:0;z-index:1}} tr:nth-child(even){{background:#fafafa}} .mono{{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,\\\"Liberation Mono\\\",monospace}} .ok{{color:#2e7d32}} .risk{{color:#ff8f00}} .break{{color:#c62828}} .chip{{display:inline-block;padding:2px 8px;border-radius:12px;font-size:12px}} .chip.ok{{background:#e8f5e9;color:#2e7d32}} .chip.risk{{background:#fff8e1;color:#ff8f00}} .chip.break{{background:#ffebee;color:#c62828}} .badge{{display:inline-block;padding:2px 6px;border-radius:6px;font-size:12px;margin-right:4px}} .badge.meta{{background:#e3f2fd;color:#1565c0}} .badge.heur{{background:#fff3e0;color:#ef6c00}}</style>"
+    )?;
+    writeln!(f, "</head><body>")?;
+    writeln!(f, "<h2>Storage Diff</h2>")?;
+    let max_grade_class = match summary.max_grade { SeverityGrade::Ok => "ok", SeverityGrade::Risk => "risk", SeverityGrade::Break => "break" };
+    writeln!(f, "<p>Added: {} &nbsp; Removed: {} &nbsp; TypeChanged: {} &nbsp; PackingChanged: {} &nbsp; Same: {} &nbsp; Max grade: <span class=\"chip {}\">{:?}</span></p>", summary.added, summary.removed, summary.type_changed, summary.packing_changed, summary.same, max_grade_class, summary.max_grade)?;
+
+    writeln!(f, "<table>")?;
+    writeln!(
+        f,
+        "<tr><th>Slot</th><th>Old</th><th>New</th><th>Status</th><th>Grade</th><th>Provenance</th></tr>"
+    )?;
+    for d in diffs {
+        let grade_class = match d.grade {
+            SeverityGrade::Ok => "ok",
+            SeverityGrade::Risk => "risk",
+            SeverityGrade::Break => "break",
+        };
+        let (old_desc, old_unknown) = match d.old.as_ref() {
+            Some(e) => (format!("{:?}", e.r#type), matches!(e.r#type, StorageType::Unknown)),
+            None => ("—".to_string(), false),
+        };
+        let (new_desc, new_unknown) = match d.new.as_ref() {
+            Some(e) => (format!("{:?}", e.r#type), matches!(e.r#type, StorageType::Unknown)),
+            None => ("—".to_string(), false),
+        };
+        let tip = "No compiler metadata available; conservative heuristic left type unknown.";
+        let old_html = if old_unknown { format!("<span title=\"{}\">{}</span>", tip, old_desc) } else { old_desc };
+        let new_html = if new_unknown { format!("<span title=\"{}\">{}</span>", tip, new_desc) } else { new_desc };
+
+        let badge = |p: Option<Provenance>| -> String {
+            match p {
+                Some(Provenance::CompilerMetadata) => "<span class=\"badge meta\">Metadata</span>".to_string(),
+                Some(Provenance::HeuristicTrace) => "<span class=\"badge heur\">Heuristic</span>".to_string(),
+                None => "—".to_string(),
+            }
+        };
+        let prov = format!("{} / {}", badge(d.provenance_old), badge(d.provenance_new));
+        let slot_cell = format!("{} (0x{:x})", d.slot, d.slot);
+        writeln!(
+            f,
+            "<tr><td class=\"mono\">{}</td><td class=\"mono\">{}</td><td class=\"mono\">{}</td><td>{:?}</td><td class=\"{}\">{:?}</td><td>{}</td></tr>",
+            slot_cell, old_html, new_html, d.status, grade_class, d.grade, prov
+        )?;
+    }
+    writeln!(f, "</table>")?;
+    writeln!(f, "</body></html>")?;
+    Ok(())
+}


### PR DESCRIPTION
**v0.3.0 – Storage Diff**

This adds a new storage-diff subcommand to evm-lens:

```
evm-lens storage-diff <old> <new> [--json out.json] [--html out.html] [--ci]
```

Gives auditors/devs a quick way to catch unsafe storage layout changes before upgrades. 
Useful for manual review (HTML) and automation (JSON + CI).